### PR TITLE
Sensor config [WiP]

### DIFF
--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -199,7 +199,7 @@ namespace imu_bno055 {
 
 // order of this struct is designed to match the I2C registers
 // so all data can be read in one fell swoop
-typedef struct {
+typedef struct __attribute__((__packed__)) {
   int16_t raw_linear_acceleration_x;
   int16_t raw_linear_acceleration_y;
   int16_t raw_linear_acceleration_z;

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -264,6 +264,9 @@ class BNO055I2CActivity {
     double param_gyro_bandwidth;
     int param_acc_range;
     int param_gyro_range;
+    bool param_enable_raw;
+    bool param_enable_data;
+    bool param_enable_status;
 
     // ROS node handles
     ros::NodeHandle nh;

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -243,6 +243,7 @@ class BNO055I2CActivity {
     bool onServiceCalibrate(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
 
   private:
+    int operation_mode();
     bool reset();
 
     // class variables
@@ -253,6 +254,7 @@ class BNO055I2CActivity {
     // ROS parameters
     std::string param_frame_id;
     std::string param_device;
+    std::string param_operation_mode;
     int param_address;
 
     // ROS node handles

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -34,6 +34,9 @@
 #define BNO055_BL_REV_ID_ADDR 0X06
 #define BNO055_PAGE_ID_ADDR 0X07
 
+#define BNO055_ACC_CONFIG 0X08 // Page 1
+#define BNO055_GYR_CONFIG_0 0X0A // Page 1
+
 #define BNO055_ACCEL_DATA_X_LSB_ADDR 0X08
 #define BNO055_ACCEL_DATA_X_MSB_ADDR 0X09
 #define BNO055_ACCEL_DATA_Y_LSB_ADDR 0X0A
@@ -244,6 +247,7 @@ class BNO055I2CActivity {
 
   private:
     int operation_mode();
+    bool configure_sensors();
     bool reset();
 
     // class variables
@@ -256,6 +260,10 @@ class BNO055I2CActivity {
     std::string param_device;
     std::string param_operation_mode;
     int param_address;
+    double param_acc_bandwidth;
+    double param_gyro_bandwidth;
+    int param_acc_range;
+    int param_gyro_range;
 
     // ROS node handles
     ros::NodeHandle nh;

--- a/imu_bno055/launch/imu.launch
+++ b/imu_bno055/launch/imu.launch
@@ -1,7 +1,21 @@
 <launch>
+    <!-- bno datasheet https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf -->
     <node ns="imu" name="imu_node" pkg="imu_bno055" type="bno055_i2c_node" respawn="true" respawn_delay="2">
         <param name="device" type="string" value="/dev/i2c-1"/>
         <param name="address" type="int" value="40"/> <!-- 0x28 == 40 is the default for BNO055 -->
         <param name="frame_id" type="string" value="imu"/>
+        <param name="operation_mode" type="string" value="ACCGYRO"/> <!-- Possible values: datasheet page 20-->
+        
+        <!--Possible values: 7.81, 15.63, 31.25,62.5, 125.0, 250.0, 500.0, 1000.0,
+        if operation_mode is set to one of Non-fusionmodes (see datasheet page 20) acc_bandwidth does not work-->
+        <param name="acc_bandwidth" type="double" value="15.63"/>  
+        
+        <!-- enabling/disabling some of the sensor data readings -->
+        <param name="enable_raw" type="bool" value="true"/>
+        <param name="enable_data" type="bool" value="false"/>
+        <param name="enable_status" type="bool" value="false"/>
+        
+        <!-- rate at which imu data is sent to ros topic (Hz) -->
+        <param name="rate" type="int" value="32"/>
     </node>
 </launch>

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "imu_bno055/bno055_i2c_activity.h"
+#include <linux/i2c.h>
 
 namespace imu_bno055 {
 
@@ -149,14 +150,31 @@ bool BNO055I2CActivity::spinOnce() {
 
     seq++;
 
-    // can only read a length of 0x20 at a time, so do it in 2 reads
-    // BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR is the start of the data block that aligns with the IMURecord struct
-    if(_i2c_smbus_read_i2c_block_data(file, BNO055_ACCEL_DATA_X_LSB_ADDR, 0x20, (uint8_t*)&record) != 0x20) {
+    unsigned char reg = BNO055_ACCEL_DATA_X_LSB_ADDR;
+
+    struct i2c_msg msgs[] {
+        {
+            .addr = (uint16_t)param_address,
+            .flags = 0,
+            .len = 1,
+            .buf = &reg,
+        },
+        {
+            /* TODO: I2C_M_NOSTART support assumed, add some code to check I2C_FUNC_NOSTART for portability */
+            .addr = (uint16_t)param_address,
+            .flags = I2C_M_RD | I2C_M_NOSTART,
+            .len = sizeof(record),
+            .buf = (unsigned char *)&record,
+        },
+    };
+
+    struct i2c_rdwr_ioctl_data msgset {
+        .msgs = msgs,
+        .nmsgs = sizeof(msgs)/sizeof(*msgs),
+    };
+
+    if (ioctl(file, I2C_RDWR, &msgset) < 0)
         return false;
-    }
-    if(_i2c_smbus_read_i2c_block_data(file, BNO055_ACCEL_DATA_X_LSB_ADDR + 0x20, 0x13, (uint8_t*)&record + 0x20) != 0x13) {
-        return false;
-    }
 
     sensor_msgs::Imu msg_raw;
     msg_raw.header.stamp = time;

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -222,8 +222,8 @@ bool BNO055I2CActivity::start() {
 
     if(!pub_data && param_enable_data) pub_data = nh.advertise<sensor_msgs::Imu>("data", 1);
     if(!pub_raw && param_enable_raw) pub_raw = nh.advertise<sensor_msgs::Imu>("raw", 1);
-    if(!pub_mag) pub_mag = nh.advertise<sensor_msgs::MagneticField>("mag", 1);
-    if(!pub_temp) pub_temp = nh.advertise<sensor_msgs::Temperature>("temp", 1);
+    if(!pub_mag && param_enable_raw) pub_mag = nh.advertise<sensor_msgs::MagneticField>("mag", 1);
+    if(!pub_temp && param_enable_status) pub_temp = nh.advertise<sensor_msgs::Temperature>("temp", 1);
     if(!pub_status && param_enable_status) pub_status = nh.advertise<diagnostic_msgs::DiagnosticStatus>("status", 1);
 
     if(!service_calibrate) service_calibrate = nh.advertiseService(

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -160,9 +160,9 @@ bool BNO055I2CActivity::spinOnce() {
             .buf = &reg,
         },
         {
-            /* TODO: I2C_M_NOSTART support assumed, add some code to check I2C_FUNC_NOSTART for portability */
+            // TODO: I2C_M_NOSTART would be nice together with I2C_M_RD but it seems to be not supported by i2c-gpio.c (I2C_FUNC_NOSTART).
             .addr = (uint16_t)param_address,
-            .flags = I2C_M_RD | I2C_M_NOSTART,
+            .flags = I2C_M_RD,
             .len = sizeof(record),
             .buf = (unsigned char *)&record,
         },

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -18,6 +18,10 @@ BNO055I2CActivity::BNO055I2CActivity(ros::NodeHandle &_nh, ros::NodeHandle &_nh_
     nh_priv.param("address", param_address, (int)BNO055_ADDRESS_A);
     nh_priv.param("frame_id", param_frame_id, (std::string)"imu");
     nh_priv.param("operation_mode", param_operation_mode, (std::string)"NDOF");
+    nh_priv.param("acc_bandwidth", param_acc_bandwidth, 62.5);
+    nh_priv.param("acc_range", param_acc_range, 4);
+    nh_priv.param("gyro_bandwidth", param_gyro_bandwidth, 32.0);
+    nh_priv.param("gyro_range", param_gyro_range, 2000);
 
     current_status.level = 0;
     current_status.name = "BNO055 IMU";
@@ -80,6 +84,80 @@ int BNO055I2CActivity::operation_mode() {
     return -1;
 }
 
+bool BNO055I2CActivity::configure_sensors() {
+    std::map<double, uint8_t> acc_bw {
+        { 7.81, 0 },
+        { 15.63, 1 },
+        { 31.25, 2 },
+        { 62.5, 3 },
+        { 125.0, 4 },
+        { 250.0, 5 },
+        { 500.0, 6 },
+        { 1000.0, 7 },
+    };
+
+    std::map<int, uint8_t> acc_range {
+        { 2, 0 },
+        { 4, 1 },
+        { 8, 2 },
+        { 16, 3 },
+    };
+
+    std::map<double, uint8_t> gyro_bw {
+        { 523.0, 0 },
+        { 230.0, 1 },
+        { 116.0, 2 },
+        { 47.0, 3 },
+        { 23.0, 4 },
+        { 12.0, 5 },
+        { 64.0, 6 },
+        { 32.0, 7 },
+    };
+
+    std::map<int, uint8_t> gyro_range {
+        { 2000, 0 },
+        { 1000, 1 },
+        { 500, 2 },
+        { 250, 3 },
+        { 125, 4 },
+    };
+
+    if (!acc_bw.count(param_acc_bandwidth)) {
+        ROS_ERROR_STREAM("Unsupported acc_bandwidth: " << param_acc_bandwidth);
+        return false;
+    }
+
+    if (!acc_range.count(param_acc_range)) {
+        ROS_ERROR_STREAM("Unsupported acc_range: " << param_acc_range);
+        return false;
+    }
+
+    if (!gyro_bw.count(param_gyro_bandwidth)) {
+        ROS_ERROR_STREAM("Unsupported gyro_bandwidth: " << param_gyro_bandwidth);
+        return false;
+    }
+
+    if (!gyro_range.count(param_gyro_range)) {
+        ROS_ERROR_STREAM("Unsupported gyro_range: " << param_gyro_range);
+        return false;
+    }
+
+    ROS_INFO_STREAM("Accelerometer range: +/-" << param_acc_range << "G, bandwidth: " << param_acc_bandwidth << "Hz");
+    ROS_INFO_STREAM("Gyroscope range: +/-" << param_gyro_range << "dps, bandwidth: " << param_gyro_bandwidth << "Hz");
+
+    uint8_t acc = acc_range.at(param_acc_range) | (acc_bw.at(param_acc_bandwidth) << 2);
+    uint8_t gyro = gyro_range.at(param_gyro_range) | (gyro_bw.at(param_gyro_bandwidth) << 3);
+
+    _i2c_smbus_write_byte_data(file, BNO055_PAGE_ID_ADDR, 1);
+
+    _i2c_smbus_write_byte_data(file, BNO055_ACC_CONFIG, acc);
+    _i2c_smbus_write_byte_data(file, BNO055_GYR_CONFIG_0, gyro);
+
+    _i2c_smbus_write_byte_data(file, BNO055_PAGE_ID_ADDR, 0);
+
+    return true;
+}
+
 bool BNO055I2CActivity::reset() {
     int i = 0;
 
@@ -116,6 +194,12 @@ bool BNO055I2CActivity::reset() {
 
     _i2c_smbus_write_byte_data(file, BNO055_OPR_MODE_ADDR, (uint8_t)opr_mode);
     ros::Duration(0.025).sleep();
+
+    if (opr_mode < BNO055_OPERATION_MODE_IMUPLUS) {
+        if (!configure_sensors()) {
+            return false;
+        }
+    }
 
     return true;
 }

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -152,12 +152,18 @@ bool BNO055I2CActivity::configure_sensors() {
     uint8_t acc = acc_range.at(param_acc_range) | (acc_bw.at(param_acc_bandwidth) << 2);
     uint8_t gyro = gyro_range.at(param_gyro_range) | (gyro_bw.at(param_gyro_bandwidth) << 3);
 
+    // TODO: Do we actually need to sleep here?
     _i2c_smbus_write_byte_data(file, BNO055_PAGE_ID_ADDR, 1);
+    ros::Duration(0.025).sleep();
 
     _i2c_smbus_write_byte_data(file, BNO055_ACC_CONFIG, acc);
+    ros::Duration(0.025).sleep();
+
     _i2c_smbus_write_byte_data(file, BNO055_GYR_CONFIG_0, gyro);
+    ros::Duration(0.025).sleep();
 
     _i2c_smbus_write_byte_data(file, BNO055_PAGE_ID_ADDR, 0);
+    ros::Duration(0.025).sleep();
 
     return true;
 }
@@ -192,6 +198,7 @@ bool BNO055I2CActivity::reset() {
     _i2c_smbus_write_byte_data(file, BNO055_PWR_MODE_ADDR, BNO055_POWER_MODE_NORMAL);
     ros::Duration(0.010).sleep();
 
+    // TODO: Do we actually need this? Page ID should be zero after reset
     _i2c_smbus_write_byte_data(file, BNO055_PAGE_ID_ADDR, 0);
     _i2c_smbus_write_byte_data(file, BNO055_SYS_TRIGGER_ADDR, 0);
     ros::Duration(0.025).sleep();

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -196,14 +196,14 @@ bool BNO055I2CActivity::reset() {
     _i2c_smbus_write_byte_data(file, BNO055_SYS_TRIGGER_ADDR, 0);
     ros::Duration(0.025).sleep();
 
-    _i2c_smbus_write_byte_data(file, BNO055_OPR_MODE_ADDR, (uint8_t)opr_mode);
-    ros::Duration(0.025).sleep();
-
     if (opr_mode < BNO055_OPERATION_MODE_IMUPLUS) {
         if (!configure_sensors()) {
             return false;
         }
     }
+
+    _i2c_smbus_write_byte_data(file, BNO055_OPR_MODE_ADDR, (uint8_t)opr_mode);
+    ros::Duration(0.025).sleep();
 
     return true;
 }

--- a/imu_bno055/src/bno055_i2c_activity.cpp
+++ b/imu_bno055/src/bno055_i2c_activity.cpp
@@ -220,11 +220,11 @@ bool BNO055I2CActivity::reset() {
 bool BNO055I2CActivity::start() {
     ROS_INFO("starting");
 
-    if(!pub_data) pub_data = nh.advertise<sensor_msgs::Imu>("data", 1);
-    if(!pub_raw) pub_raw = nh.advertise<sensor_msgs::Imu>("raw", 1);
+    if(!pub_data && param_enable_data) pub_data = nh.advertise<sensor_msgs::Imu>("data", 1);
+    if(!pub_raw && param_enable_raw) pub_raw = nh.advertise<sensor_msgs::Imu>("raw", 1);
     if(!pub_mag) pub_mag = nh.advertise<sensor_msgs::MagneticField>("mag", 1);
     if(!pub_temp) pub_temp = nh.advertise<sensor_msgs::Temperature>("temp", 1);
-    if(!pub_status) pub_status = nh.advertise<diagnostic_msgs::DiagnosticStatus>("status", 1);
+    if(!pub_status && param_enable_status) pub_status = nh.advertise<diagnostic_msgs::DiagnosticStatus>("status", 1);
 
     if(!service_calibrate) service_calibrate = nh.advertiseService(
         "calibrate",
@@ -569,7 +569,7 @@ bool BNO055I2CActivity::spinOnce() {
         pub_temp.publish(msg_temp);
     }
 
-    if(seq % 50 == 0) {
+    if(param_enable_status && seq % 50 == 0) {
         current_status.values[DIAG_CALIB_STAT].value = std::to_string(record.calibration_status);
         current_status.values[DIAG_SELFTEST_RESULT].value = std::to_string(record.self_test_result);
         current_status.values[DIAG_INTR_STAT].value = std::to_string(record.interrupt_status);


### PR DESCRIPTION
Not well tested yet :-)

This adds the following parameters:

- `operation_mode` (string, operation mode from *Table 3-3: Operating modes overview*)
- `acc_range` (int, values from *Table 3-8: Accelerometer configurations* [G])
- `acc_bandwidth` (double, values from *Table 3-8: Accelerometer configurations* [Hz])
- `gyro_range` (int, values from *Table 3-9: Gyroscope configurations* [dps])
- `gyro_bandwidth` (double, values from *Table 3-9: Gyroscope configurations* [Hz])

The `{acc,gyro}_{range,bandwidth}` parameters are configured only when `operation_mode` is not in the Fusion mode, otherwise the range and bandwidth are controlled by the fusion algorithm.

Example:

```
        <param name="operation_mode" type="string" value="ACCGYRO"/>
        <param name="acc_bandwidth" type="double" value="31.25"/>
```

**STEPS TO ENABLE BITBANGING ON  RASPBERRYPI:** 

IMU BNO055 is used with communication setup through I2C. If bitbanging is not enabled high random peaks in IMU raw and fused data can be experienced

First disable the HW I2C in `/boot/config.txt` -- just comment it out by putting `#` infront of the following line so in the end it looks like this:

    #dtparam=i2c_arm=on

Then add the following line to use a bit-banged driver for /dev/i2c-1 on the
"original" I2C pins:

    dtoverlay=i2c-gpio,i2c_gpio_sda=2,i2c_gpio_scl=3,bus=1

After reboot, check dmesg to verify the bit-banged driver is correctly initialized:

	ubuntu@ubiquityrobot:~$ dmesg | grep -i i2c
	[    2.882085] i2c-gpio 100000002.i2c: using lines 2 (SDA) and 3 (SCL)